### PR TITLE
Implement jobworker library

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,7 +68,6 @@ type JobOutput struct {
      - Waits for process completion
      - Sets `cgroup.kill` to 1 to clean up stray processes
      - Attempts to remove the cgroup with no retry, for simplicity
-     - Removes the `Job` from the map of jobs in memory
 - Each job will have:
   - A dedicated directory in `/tmp/jobworker/<job_id>/`
   - A single output file containing both stdout and stderr
@@ -113,7 +112,7 @@ type JobOutput struct {
 - `StopJob` will:
   1. set `cgroup.kill` to 1 in the job's cgroup to kill all processes from that job
   2. attempt once to remove the cgroup with no retry, for simplicity
-  3. remove the `Job` from the map of jobs in memory
+  3. Set the `JobStatus` to STOPPED.
 
 ### 2. gRPC API Server
 
@@ -155,8 +154,12 @@ $ jobworker-cli stream "c06eede4-27e1-48e6-9df5-17becdd9b385"
 $ jobworker-cli stop "c06eede4-27e1-48e6-9df5-17becdd9b385"
 Job stop requested
 
-# Try to stop a non-existent job
+# Stop a job a second time
 $ jobworker-cli stop "c06eede4-27e1-48e6-9df5-17becdd9b385"
+Job stop requested
+
+# Try to stop a non-existent job
+$ jobworker-cli stop "be650871-f6e2-4a80-9b3d-9710f33cc628"
 Error: Job not found
 
 # Get status after stopping
@@ -301,7 +304,8 @@ Start the server:
 
 #### Requirements
 
-NOTE: The server expects cgroupsv2 to be available on the system and will return an error if only cgroupsv1 is available.
+NOTE: The server expects:
+* cgroupsv2 to be available on the system and will return an error if only cgroupsv1 is available
 
 ### Running the CLI
 

--- a/library/job_manager.go
+++ b/library/job_manager.go
@@ -1,0 +1,464 @@
+package library
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/google/uuid"
+)
+
+// Hardcoded cgroup limits
+const (
+	// CPU: 25% of a single CPU core
+	cpuMax = "25000 100000"
+	// Memory: 256MB (268435456 bytes)
+	memoryHigh = "268435456"
+	// IO: Very low weight to throttle disk I/O
+	ioWeight = "default 10"
+)
+
+// Path constants
+const (
+	baseCgroupPath = "/sys/fs/cgroup/"
+	parentCgroup   = "jobworker.slice/"
+	jobScope       = "job-%s.scope"
+	jobBaseDir     = "/tmp/jobworker/%s"
+)
+
+var (
+	parentCgroupPath = baseCgroupPath + parentCgroup
+	jobScopePath     = baseCgroupPath + parentCgroup + jobScope
+)
+
+const (
+	cgroupControllers    = "+cpu +io +memory" // Cgroup controllers to enable
+	cgroupSubtreeControl = "cgroup.subtree_control"
+	cgroupKill           = "cgroup.kill"
+)
+
+const outputBufferSize = 4096
+
+type jobManager struct {
+	jobs        map[string]*Job
+	stoppedJobs map[string]*Job
+	jobsMux     sync.RWMutex
+}
+
+// checkPrerequisites verifies system requirements for the job worker
+func checkPrerequisites() error {
+	// Check root access
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("job worker requires root privileges")
+	}
+
+	// Initialize cgroup setup
+	if err := setupCgroups(); err != nil {
+		return fmt.Errorf("failed to initialize cgroup setup: %w", err)
+	}
+
+	return nil
+}
+
+func setupCgroups() error {
+	// Check if cgroupsv2 is mounted
+	mounts, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return fmt.Errorf("failed to read cgroups mounts: %w", err)
+	}
+	if !strings.Contains(string(mounts), "cgroup2") {
+		return fmt.Errorf("cgroups2 is not available in the system")
+	}
+
+	if err := os.MkdirAll(parentCgroupPath, 0755); err != nil {
+		return fmt.Errorf("failed to create parent cgroup directory: %w", err)
+	}
+
+	// Enable required controllers in the parent cgroup
+	if err := os.WriteFile(filepath.Join(parentCgroupPath, cgroupSubtreeControl), []byte(cgroupControllers), 0644); err != nil {
+		return fmt.Errorf("failed to enable cgroup controllers: %w", err)
+	}
+	return nil
+}
+
+// isIOWeightAvailable checks if io.weight is available (requires `cfq` or `bfq` scheduler)
+func isIOWeightAvailable(cgroupPath string) bool {
+	ioWeightPath := filepath.Join(cgroupPath, "io.weight")
+	_, err := os.Stat(ioWeightPath)
+	return err == nil
+}
+
+// setCgroupLimit sets a cgroup limit
+func setCgroupLimit(cgroupPath, limitFile string, value []byte) error {
+	if err := os.WriteFile(filepath.Join(cgroupPath, limitFile), value, 0644); err != nil {
+		return fmt.Errorf("failed to set %s limit: %w", limitFile, err)
+	}
+	return nil
+}
+
+// cleanupResources handles cleanup of all resources associated with a job
+func cleanupResources(outputFile *os.File, jobDir, cgroupPath string) {
+	if outputFile != nil {
+		outputFile.Close()
+	}
+	if jobDir != "" {
+		os.RemoveAll(jobDir)
+	}
+	if cgroupPath != "" {
+		os.RemoveAll(cgroupPath)
+	}
+}
+
+func NewJobManager() JobManager {
+	// Check system prerequisites
+	if err := checkPrerequisites(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// This check is non-blocking - the service will continue to run even if IO weight
+	// is unavailable. IO limits will simply not be enforced in this case.
+	if !isIOWeightAvailable(parentCgroupPath) {
+		fmt.Printf("Warning: io.weight is unavailable, IO limits will not be enforced. Consider enabling `cfq` or `bfq` scheduler.\n")
+	}
+
+	return &jobManager{
+		jobs:        make(map[string]*Job),
+		stoppedJobs: make(map[string]*Job),
+	}
+}
+
+// setupJobDirectories creates the job directory and output file
+func (m *jobManager) setupJobDirectories(id string) (*os.File, string, error) {
+	// Create job output directory
+	jobDir := fmt.Sprintf(jobBaseDir, id)
+	if err := os.MkdirAll(jobDir, 0755); err != nil {
+		return nil, "", &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to create job directory: %v", err),
+		}
+	}
+
+	// Create output file in the job directory
+	outputFile, err := os.Create(filepath.Join(jobDir, "output.log"))
+	if err != nil {
+		os.RemoveAll(jobDir)
+		return nil, "", &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to create output file: %v", err),
+		}
+	}
+
+	return outputFile, jobDir, nil
+}
+
+// setupCgroup creates and configures the cgroup for a job
+func (m *jobManager) setupCgroup(id string) (string, error) {
+	cgroupPath := fmt.Sprintf(jobScopePath, id)
+	if err := os.MkdirAll(cgroupPath, 0755); err != nil {
+		return "", &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to create cgroup: %v", err),
+		}
+	}
+
+	// Set resource limits
+	if err := setCgroupLimit(cgroupPath, "cpu.max", []byte(cpuMax)); err != nil {
+		return "", err
+	}
+	if err := setCgroupLimit(cgroupPath, "memory.high", []byte(memoryHigh)); err != nil {
+		return "", err
+	}
+
+	// Set IO weight if available
+	if isIOWeightAvailable(cgroupPath) {
+		if err := setCgroupLimit(cgroupPath, "io.weight", []byte(ioWeight)); err != nil {
+			return "", err
+		}
+	}
+
+	return cgroupPath, nil
+}
+
+// startProcess starts the process in its cgroup
+func (m *jobManager) startProcess(cmd *exec.Cmd, cgroupPath string) error {
+	// Get cgroupFD for the process
+	cgroupFD, err := syscall.Open(cgroupPath, syscall.O_RDONLY, 0)
+	if err != nil {
+		return &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to open cgroup directory: %v", err),
+		}
+	}
+	defer syscall.Close(cgroupFD)
+
+	// Set process to start in the cgroup
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		UseCgroupFD: true,
+		CgroupFD:    cgroupFD,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to start process: %v", err),
+		}
+	}
+
+	return nil
+}
+
+// monitorJob monitors the job's completion and handles cleanup
+func (m *jobManager) monitorJob(job *Job, cgroupPath string) {
+	job.cmd.Wait()
+	m.jobsMux.Lock()
+	defer m.jobsMux.Unlock()
+
+	if job, exists := m.jobs[job.ID]; exists {
+		// Update job status based on exit code
+		exitCode := job.cmd.ProcessState.ExitCode()
+		if exitCode == 0 {
+			job.status = StatusCompleted
+		} else if exitCode == -1 {
+			// For exit code -1, we need to check if the process was actually started
+			if job.cmd.ProcessState != nil && job.cmd.ProcessState.Pid() > 0 {
+				// Process was started and terminated by a signal
+				job.status = StatusStopped
+			} else {
+				// Process never started
+				job.status = StatusFailed
+			}
+		} else {
+			job.status = StatusFailed
+		}
+		job.hasExited = true
+
+		// Broadcast to wake up any waiting readers
+		job.dataAvailable.Broadcast()
+
+		// Set cgroup.kill to 1 to clean up stray processes
+		if err := os.WriteFile(filepath.Join(cgroupPath, cgroupKill), []byte("1"), 0644); err != nil {
+			fmt.Printf("warning: failed to set cgroup.kill for job %s: %v\n", job.ID, err)
+		}
+
+		// Attempt to remove the cgroup with no retry, for simplicity
+		if err := os.RemoveAll(cgroupPath); err != nil {
+			fmt.Printf("warning: failed to remove cgroup for job %s: %v\n", job.ID, err)
+		}
+	}
+}
+
+// StartJob implements JobManager.StartJob
+func (m *jobManager) StartJob(ctx context.Context, command string, args []string) (*Job, error) {
+	// Generate a unique ID for the job
+	id := uuid.NewString()
+
+	// Set up cleanup for any failures during job creation
+	success := false
+	var outputFile *os.File
+	var jobDir string
+	var cgroupPath string
+
+	defer func() {
+		if !success {
+			cleanupResources(outputFile, jobDir, cgroupPath)
+		}
+	}()
+
+	// Create job directories and output file
+	outputFile, jobDir, err := m.setupJobDirectories(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up cgroup
+	cgroupPath, err = m.setupCgroup(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create and start process
+	cmd := exec.CommandContext(ctx, command, args...)
+	writer := newJobWriter(outputFile, nil) // Will be set after job creation
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+
+	// Create job
+	job := &Job{
+		ID:        id,
+		cmd:       cmd,
+		status:    StatusRunning,
+		hasExited: false,
+		mu:        sync.Mutex{},
+		output: &JobOutput{
+			mu:      sync.RWMutex{},
+			file:    outputFile,
+			baseDir: jobDir,
+			jobID:   id,
+		},
+	}
+	job.dataAvailable = sync.NewCond(&job.mu)
+	writer.cond = job.dataAvailable
+
+	// Start process
+	if err := m.startProcess(cmd, cgroupPath); err != nil {
+		return nil, err
+	}
+
+	// Register job
+	m.jobsMux.Lock()
+	m.jobs[id] = job
+	m.jobsMux.Unlock()
+
+	// Mark job creation as successful to disable automatic cleanup
+	success = true
+
+	// Start monitoring
+	go m.monitorJob(job, cgroupPath)
+
+	return job, nil
+}
+
+// StopJob implements JobManager.StopJob
+func (m *jobManager) StopJob(ctx context.Context, jobID string) error {
+	// First check if job exists
+	m.jobsMux.RLock()
+	job, exists := m.jobs[jobID]
+	if !exists {
+		m.jobsMux.RUnlock()
+		return &JobManagerError{
+			Code:    StatusNotFound,
+			Message: fmt.Sprintf("job %s not found", jobID),
+		}
+	}
+	m.jobsMux.RUnlock()
+
+	// If job is already stopped, return success
+	if job.status != StatusRunning {
+		return nil
+	}
+
+	// Set cgroup.kill to 1 to kill all processes in the cgroup
+	cgroupPath := fmt.Sprintf(jobScopePath, jobID)
+	if err := os.WriteFile(filepath.Join(cgroupPath, cgroupKill), []byte("1"), 0644); err != nil {
+		return &JobManagerError{
+			Code:    StatusInternal,
+			Message: fmt.Sprintf("failed to kill cgroup: %v", err),
+		}
+	}
+
+	// Attempt to remove the cgroup with no retry, as per design
+	if err := os.RemoveAll(cgroupPath); err != nil {
+		fmt.Printf("warning: failed to remove cgroup %s: %v\n", cgroupPath, err)
+	}
+
+	// Only lock when modifying the jobs map
+	m.jobsMux.Lock()
+	job.status = StatusStopped
+	m.jobsMux.Unlock()
+
+	return nil
+}
+
+// GetJobStatus implements JobManager.GetJobStatus
+func (m *jobManager) GetJobStatus(ctx context.Context, jobID string) (*Job, error) {
+	m.jobsMux.RLock()
+	defer m.jobsMux.RUnlock()
+
+	if job, exists := m.jobs[jobID]; exists {
+		return job, nil
+	}
+
+	if job, exists := m.stoppedJobs[jobID]; exists {
+		return job, nil
+	}
+
+	return nil, &JobManagerError{
+		Code:    StatusNotFound,
+		Message: fmt.Sprintf("job %s not found", jobID),
+	}
+}
+
+// StreamOutput implements JobManager.StreamOutput
+func (m *jobManager) StreamOutput(ctx context.Context, jobID string) (<-chan []byte, error) {
+	m.jobsMux.RLock()
+	job, exists := m.jobs[jobID]
+	m.jobsMux.RUnlock()
+
+	if !exists {
+		return nil, &JobManagerError{
+			Code:    StatusNotFound,
+			Message: fmt.Sprintf("job %s not found", jobID),
+		}
+	}
+
+	// Create output channel
+	outputChan := make(chan []byte)
+
+	// Start reading from the beginning of the file
+	go func() {
+		defer close(outputChan)
+
+		// Open file in read-only mode
+		file, err := os.OpenFile(job.output.file.Name(), os.O_RDONLY, 0)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		// Create output reader
+		reader := &OutputReader{
+			file: file,
+			pos:  0,
+			job:  job,
+		}
+
+		// Read from the beginning
+		buf := make([]byte, outputBufferSize)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// Seek to our last position
+				if _, err := reader.file.Seek(reader.pos, io.SeekStart); err != nil {
+					return
+				}
+
+				nBytes, err := reader.file.Read(buf)
+				if err != nil {
+					if err == io.EOF {
+						// Check if process has terminated
+						if reader.job.hasExited {
+							return
+						}
+						// Process is still running, wait for more data
+						reader.job.dataAvailable.L.Lock()
+						reader.job.dataAvailable.Wait()
+						reader.job.dataAvailable.L.Unlock()
+						continue
+					}
+					return
+				}
+
+				// Update our position
+				reader.pos += int64(nBytes)
+
+				// Send data to channel
+				select {
+				case outputChan <- buf[:nBytes]:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return outputChan, nil
+}

--- a/library/job_manager_test.go
+++ b/library/job_manager_test.go
@@ -1,0 +1,276 @@
+package library
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJobManager_StartJob(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "simple command",
+			command: "echo",
+			args:    []string{"hello"},
+			wantErr: false,
+		},
+		{
+			name:    "command with output",
+			command: "yes",
+			args:    []string{"test"},
+			wantErr: false,
+		},
+		{
+			name:    "nonexistent command",
+			command: "nonexistentcommand",
+			args:    []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewJobManager()
+			ctx := context.Background()
+
+			job, err := m.StartJob(ctx, tt.command, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StartJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Verify job directory exists
+				jobDir := filepath.Join("/tmp/jobworker", job.ID)
+				if _, err := os.Stat(jobDir); os.IsNotExist(err) {
+					t.Errorf("job directory %s does not exist", jobDir)
+				}
+
+				// Verify output file exists
+				outputFile := filepath.Join(jobDir, "output.log")
+				if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+					t.Errorf("output file %s does not exist", outputFile)
+				}
+
+				// Verify cgroup exists and has correct limits
+				cgroupPath := filepath.Join("/sys/fs/cgroup/jobworker.slice", "job-"+job.ID+".scope")
+				if _, err := os.Stat(cgroupPath); os.IsNotExist(err) {
+					t.Errorf("cgroup directory %s does not exist", cgroupPath)
+				}
+
+				// Check required cgroup limits
+				checkCgroupLimit(t, cgroupPath, "cpu.max", cpuMax)
+				checkCgroupLimit(t, cgroupPath, "memory.high", memoryHigh)
+
+				// Check IO weight only if available
+				if isIOWeightAvailable(cgroupPath) {
+					checkCgroupLimit(t, cgroupPath, "io.weight", ioWeight)
+				} else {
+					t.Log("io.weight is not available, skipping IO weight check")
+				}
+
+				// Cleanup
+				m.StopJob(ctx, job.ID)
+			}
+		})
+	}
+}
+
+func TestJobManager_StopJob(t *testing.T) {
+	m := NewJobManager()
+	ctx := context.Background()
+
+	// Start a long-running job
+	job, err := m.StartJob(ctx, "sleep", []string{"100"})
+	if err != nil {
+		t.Fatalf("Failed to start job: %v", err)
+	}
+
+	// Stop the job
+	err = m.StopJob(ctx, job.ID)
+	if err != nil {
+		t.Errorf("StopJob() error = %v", err)
+	}
+
+	// Verify job is stopped but still accessible
+	stoppedJob, err := m.GetJobStatus(ctx, job.ID)
+	if err != nil {
+		t.Errorf("GetJobStatus() error = %v", err)
+	}
+	if stoppedJob.status != StatusStopped {
+		t.Errorf("GetJobStatus() status = %v, want %v", stoppedJob.status, StatusStopped)
+	}
+
+	// Verify cgroup is removed
+	cgroupPath := filepath.Join("/sys/fs/cgroup/jobworker.slice", "job-"+job.ID+".scope")
+	if _, err := os.Stat(cgroupPath); !os.IsNotExist(err) {
+		t.Errorf("cgroup directory %s still exists", cgroupPath)
+	}
+}
+
+func checkCgroupLimit(t *testing.T, cgroupPath, limitFile, expectedValue string) {
+	content, err := os.ReadFile(filepath.Join(cgroupPath, limitFile))
+	if err != nil {
+		t.Errorf("Failed to read %s: %v", limitFile, err)
+		return
+	}
+
+	// Trim any whitespace and newlines from both values
+	actual := strings.TrimSpace(string(content))
+	expected := strings.TrimSpace(expectedValue)
+
+	if actual != expected {
+		t.Errorf("%s = %q, want %q", limitFile, actual, expected)
+	}
+}
+
+func TestNewJobManager(t *testing.T) {
+	// Test that NewJobManager returns a non-nil JobManager
+	manager := NewJobManager()
+	if manager == nil {
+		t.Error("NewJobManager returned nil")
+	}
+
+	// Test that the parent cgroup was created
+	if _, err := os.Stat(parentCgroupPath); os.IsNotExist(err) {
+		t.Errorf("Parent cgroup directory %s was not created", parentCgroupPath)
+	}
+
+	// Test that the required controllers were enabled
+	controllers, err := os.ReadFile(filepath.Join(parentCgroupPath, cgroupSubtreeControl))
+	if err != nil {
+		t.Errorf("Failed to read cgroup.subtree_control: %v", err)
+	}
+
+	if !strings.Contains(string(controllers), "cpu") ||
+		!strings.Contains(string(controllers), "memory") ||
+		!strings.Contains(string(controllers), "io") {
+		t.Error("Required controllers (cpu, memory, io) were not enabled")
+	}
+}
+
+func TestJobManager_OutputLogging(t *testing.T) {
+	m := NewJobManager()
+	ctx := context.Background()
+
+	// Start a job that will produce output
+	expectedOutput := "test output"
+	job, err := m.StartJob(ctx, "echo", []string{expectedOutput})
+	if err != nil {
+		t.Fatalf("Failed to start job: %v", err)
+	}
+
+	// Wait a short time for the job to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify output file exists and contains expected content
+	outputPath := filepath.Join("/tmp/jobworker", job.ID, "output.log")
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Errorf("Failed to read output file: %v", err)
+	}
+
+	// Check that the output contains our expected string
+	// Note: echo adds a newline, so we trim it for comparison
+	if strings.TrimSpace(string(content)) != expectedOutput {
+		t.Errorf("Output file content = %q, want %q", strings.TrimSpace(string(content)), expectedOutput)
+	}
+
+	// Clean up
+	if err := m.StopJob(ctx, job.ID); err != nil {
+		t.Errorf("Failed to stop job: %v", err)
+	}
+}
+
+func TestJobManager_StreamOutput(t *testing.T) {
+	m := NewJobManager()
+	ctx := context.Background()
+
+	// Create a script that will output in two phases
+	script := `#!/bin/bash
+echo "first output"
+sleep 0.5
+echo "second output"
+`
+	scriptPath := filepath.Join(os.TempDir(), "test_script.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create test script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+
+	// Start the job
+	job, err := m.StartJob(ctx, scriptPath, nil)
+	if err != nil {
+		t.Fatalf("Failed to start job: %v", err)
+	}
+
+	outputChan, err := m.StreamOutput(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("Failed to start streaming: %v", err)
+	}
+
+	// Collect all output
+	var output []string
+	for data := range outputChan {
+		output = append(output, strings.TrimSpace(string(data)))
+	}
+
+	// Clean up
+	if err := m.StopJob(ctx, job.ID); err != nil {
+		t.Errorf("Failed to stop job: %v", err)
+	}
+
+	// Verify we got both outputs in the correct order
+	if len(output) != 2 {
+		t.Fatalf("Got %d outputs, want 2", len(output))
+	}
+	if output[0] != "first output" {
+		t.Errorf("First output = %q, want %q", output[0], "first output")
+	}
+	if output[1] != "second output" {
+		t.Errorf("Second output = %q, want %q", output[1], "second output")
+	}
+}
+
+func TestJobManager_StopJobTwice(t *testing.T) {
+	m := NewJobManager()
+	ctx := context.Background()
+
+	// Start a long-running job
+	job, err := m.StartJob(ctx, "sleep", []string{"100"})
+	if err != nil {
+		t.Fatalf("Failed to start job: %v", err)
+	}
+
+	// First stop should succeed
+	if err := m.StopJob(ctx, job.ID); err != nil {
+		t.Errorf("First StopJob() error = %v", err)
+	}
+
+	// Second stop should also succeed (idempotent)
+	if err := m.StopJob(ctx, job.ID); err != nil {
+		t.Errorf("Second StopJob() error = %v", err)
+	}
+
+	// Try to stop a non-existent job
+	nonExistentID := "non-existent-id"
+	err = m.StopJob(ctx, nonExistentID)
+	if err == nil {
+		t.Error("StopJob() on non-existent job expected error, got nil")
+		return
+	}
+
+	// Check the status code
+	jobErr := err.(*JobManagerError)
+	if jobErr.Code != StatusNotFound {
+		t.Errorf("StopJob() on non-existent job returned wrong status code: %d, want %d", jobErr.Code, StatusNotFound)
+	}
+}


### PR DESCRIPTION
Implement the jobworker library, specifically:
* StartJob
* StopJob
* GetJobStatus
* StreamOutput

Add tests for:
* enable cgroup controllers
* `echo hello`
* `yes test`
* `nonexistentcommand`
* StopJob -> GetJobStatus
* `echo test output` is written to output.log
* StartJob -> StreamOutput -> (program sleeps) -> resume output
* StartJob -> StopJob(jobID) -> StopJob(jobID) -> StopJob(non-existent-id)

Update the Design Document:
* Keep the completed jobs in memory so that we can get the JobStatus and exit code later.
* Add CLI example about stopping an already-stopped job
* update "non-existent job" UUID